### PR TITLE
Add API pages and backend script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # KyaMovVM.github.io
+
+This repository hosts a simple demo site with a rotating 3D car and Material Design colors.  
+Additional pages provide an API log viewer and basic documentation. A small Python
+script (`backend_tools.py`) demonstrates how backend interactions over SSH and
+HTTP requests could be performed.
+
+## Pages
+- **index.html** – main demo with the 3D car animation.
+- **api.html** – placeholder interface for viewing backend logs.
+- **docs.html** – minimal API documentation.
+
+## Backend script
+`backend_tools.py` connects to a host via SSH and performs HTTP GET requests. It
+is only an example, credentials must be updated before use.

--- a/api.html
+++ b/api.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>API Logs</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="styless.css">
+</head>
+<body>
+    <nav class="main-nav">
+        <a href="index.html">Home</a>
+        <a href="api.html">API Logs</a>
+        <a href="docs.html">Docs</a>
+    </nav>
+    <main class="container">
+        <h1>Backend Logs</h1>
+        <ul id="log-menu">
+            <li><button onclick="showLog('error')">Error Logs</button></li>
+            <li><button onclick="showLog('access')">Access Logs</button></li>
+        </ul>
+        <pre id="log-output"></pre>
+    </main>
+    <script>
+        function showLog(type) {
+            document.getElementById('log-output').textContent = 'Loading ' + type + ' logs...';
+            // Future fetch() call can be placed here
+        }
+    </script>
+</body>
+</html>

--- a/backend_tools.py
+++ b/backend_tools.py
@@ -1,0 +1,30 @@
+"""Simple backend interface for SSH commands and HTTP requests."""
+import paramiko
+import requests
+
+
+def run_ssh_command(host: str, username: str, password: str, command: str) -> str:
+    """Execute a command on a remote host via SSH and return its output."""
+    ssh = paramiko.SSHClient()
+    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    ssh.connect(hostname=host, username=username, password=password)
+    stdin, stdout, stderr = ssh.exec_command(command)
+    output = stdout.read().decode()
+    ssh.close()
+    return output
+
+
+def fetch_url(url: str) -> str:
+    """Perform a GET request and return the response text."""
+    response = requests.get(url)
+    response.raise_for_status()
+    return response.text
+
+
+if __name__ == "__main__":
+    # Example usage placeholders
+    HOST = "example.com"
+    USER = "user"
+    PASSWORD = "password"
+    print(run_ssh_command(HOST, USER, PASSWORD, "echo hello"))
+    print(fetch_url("https://example.com"))

--- a/backend_tools.py
+++ b/backend_tools.py
@@ -3,7 +3,12 @@ import paramiko
 import requests
 
 
-def run_ssh_command(host: str, username: str, password: str, command: str) -> str:
+def run_ssh_command(
+    host: str,
+    username: str,
+    password: str,
+    command: str,
+) -> str:
     """Execute a command on a remote host via SSH and return its output."""
     ssh = paramiko.SSHClient()
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())

--- a/docs.html
+++ b/docs.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>API Documentation</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="styless.css">
+</head>
+<body>
+    <nav class="main-nav">
+        <a href="index.html">Home</a>
+        <a href="api.html">API Logs</a>
+        <a href="docs.html">Docs</a>
+    </nav>
+    <main class="container">
+        <h1>API Documentation</h1>
+        <section>
+            <h2>Endpoints</h2>
+            <p><strong>GET /api/logs</strong> - Retrieve backend log entries.</p>
+            <p><strong>POST /api/logs</strong> - Submit a new log entry.</p>
+        </section>
+    </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -2,19 +2,38 @@
 <html>
     <head>
         <title>hey</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" href="styless.css">
     </head>
     <body>
-        <img src="kya.jpg" height="200px" style="position: absolute; right: 0px;">
-        <div class="heart"></div>
-        <div id="car-container"></div>
+        <nav class="main-nav">
+            <a href="index.html">Home</a>
+            <a href="api.html">API Logs</a>
+            <a href="docs.html">Docs</a>
+        </nav>
+        <main class="container">
+            <img src="kya.jpg" alt="Image" class="banner">
+            <div class="heart"></div>
+            <div id="car-container"></div>
+        </main>
         <script src="https://unpkg.com/three@0.160.0/build/three.min.js"></script>
         <script>
             const scene = new THREE.Scene();
-            const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+            const camera = new THREE.PerspectiveCamera(75, 1, 0.1, 1000);
             const renderer = new THREE.WebGLRenderer({ antialias: true });
-            renderer.setSize(600, 400);
-            document.getElementById('car-container').appendChild(renderer.domElement);
+            const container = document.getElementById('car-container');
+            container.appendChild(renderer.domElement);
+
+            function resize() {
+                const width = container.clientWidth;
+                const height = container.clientHeight;
+                renderer.setSize(width, height);
+                camera.aspect = width / height;
+                camera.updateProjectionMatrix();
+            }
+
+            window.addEventListener('resize', resize);
+            resize();
 
             const ambientLight = new THREE.AmbientLight(0xffffff, 0.7);
             scene.add(ambientLight);
@@ -23,20 +42,26 @@
             scene.add(dirLight);
 
             const car = new THREE.Group();
+            const MATERIAL_COLORS = {
+                primary: 0x6750a4,
+                secondary: 0x625b71,
+                onSurface: 0x1c1b1f
+            };
+
             const bodyGeom = new THREE.BoxGeometry(4, 1, 2);
-            const bodyMat = new THREE.MeshPhongMaterial({ color: 0x00ffff });
+            const bodyMat = new THREE.MeshStandardMaterial({ color: MATERIAL_COLORS.primary });
             const body = new THREE.Mesh(bodyGeom, bodyMat);
             body.position.y = 0.5;
             car.add(body);
 
             const roofGeom = new THREE.BoxGeometry(2, 0.5, 1.5);
-            const roofMat = new THREE.MeshPhongMaterial({ color: 0xff00ff });
+            const roofMat = new THREE.MeshStandardMaterial({ color: MATERIAL_COLORS.secondary });
             const roof = new THREE.Mesh(roofGeom, roofMat);
             roof.position.set(-0.5, 1.0, 0);
             car.add(roof);
 
             const wheelGeom = new THREE.CylinderGeometry(0.4, 0.4, 0.6, 20);
-            const wheelMat = new THREE.MeshPhongMaterial({ color: 0x000000 });
+            const wheelMat = new THREE.MeshStandardMaterial({ color: MATERIAL_COLORS.onSurface });
             for (let x of [-1.5, 1.5]) {
                 for (let z of [-1, 1]) {
                     const wheel = new THREE.Mesh(wheelGeom, wheelMat);

--- a/styless.css
+++ b/styless.css
@@ -1,9 +1,6 @@
-body{
-  background-color: rgb(255, 255, 255);
-}
-
 body {
-  height: 900px;
+  min-height: 100vh;
+  margin: 0;
   background: linear-gradient(45deg, #00e5ff, #fb04ff);
 }
 
@@ -49,8 +46,33 @@ body {
   }
 
 #car-container {
-  width: 600px;
-  height: 400px;
+  width: 100%;
+  max-width: 600px;
+  aspect-ratio: 3 / 2;
   margin: 20px auto;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+
+nav.main-nav {
+  display: flex;
+  gap: 1rem;
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.3);
+}
+
+nav.main-nav a {
+  color: #000;
+  text-decoration: none;
+  font-weight: bold;
 }
 


### PR DESCRIPTION
## Summary
- add nav menu linking to new pages
- create `api.html` log viewer
- create `docs.html` with minimal API documentation
- include `backend_tools.py` for SSH and HTTP examples
- update README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6859dc8e5aa4833286de687f7c963c82