### PR TITLE
Add Fail2Ban logs page with UML

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ HTTP requests could be performed.
 ## Pages
 - **index.html** – main demo with the 3D car animation.
 - **api.html** – placeholder interface for viewing backend logs.
+- **fail2ban.html** – interface for viewing Fail2Ban logs.
 - **docs.html** – minimal API documentation.
 
-Each page includes a menu entry to show a transparent UML overlay with a simple architecture diagram (`uml-diagram.svg`).
+Each page includes a menu entry to show a transparent UML overlay with a simple architecture diagram (`uml-diagram.svg`). The Fail2Ban page uses <code>fail2ban-uml.svg</code>.
 
 ## Backend script
 `backend_tools.py` connects to a host via SSH and performs HTTP GET requests. It

--- a/docs.html
+++ b/docs.html
@@ -9,6 +9,7 @@
     <nav class="main-nav">
         <a href="index.html">Home</a>
         <a href="api.html">API Logs</a>
+        <a href="fail2ban.html">Fail2Ban</a>
         <a href="docs.html">Docs</a>
         <a href="#" onclick="toggleUml()">UML</a>
     </nav>
@@ -23,6 +24,12 @@
             <h2>API Logs Page</h2>
             <p>The <em>Error Logs</em> button fetches backend error logs.</p>
             <p>The <em>Access Logs</em> button retrieves access logs from the server.</p>
+        </section>
+        <section>
+            <h2>Fail2Ban Page</h2>
+            <p>The <em>Jail Status</em> button shows active jails.</p>
+            <p>The <em>Banned IPs</em> button lists blocked addresses.</p>
+            <p>The UML overlay on this page displays <code>fail2ban-uml.svg</code>.</p>
         </section>
     </main>
     <div id="uml-overlay" class="uml-overlay">

--- a/fail2ban-uml.svg
+++ b/fail2ban-uml.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="350" height="140">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="6" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="black" />
+    </marker>
+  </defs>
+  <rect x="20" y="40" width="80" height="40" fill="#e0e0e0" stroke="#000" />
+  <text x="60" y="65" text-anchor="middle" font-family="sans-serif" font-size="12">Fail2Ban</text>
+
+  <rect x="135" y="40" width="80" height="40" fill="#e0e0e0" stroke="#000" />
+  <text x="175" y="65" text-anchor="middle" font-family="sans-serif" font-size="12">Jails</text>
+
+  <rect x="250" y="40" width="80" height="40" fill="#e0e0e0" stroke="#000" />
+  <text x="290" y="65" text-anchor="middle" font-family="sans-serif" font-size="12">Bans</text>
+
+  <line x1="100" y1="60" x2="135" y2="60" stroke="#000" marker-end="url(#arrow)" />
+  <line x1="215" y1="60" x2="250" y2="60" stroke="#000" marker-end="url(#arrow)" />
+</svg>

--- a/fail2ban.html
+++ b/fail2ban.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>API Logs</title>
+    <title>Fail2Ban Logs</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="styles.css">
 </head>
@@ -14,30 +14,31 @@
         <a href="#" onclick="toggleUml()">UML</a>
     </nav>
     <main class="container">
-        <h1>Backend Logs</h1>
+        <h1>Fail2Ban Logs</h1>
         <ul id="log-menu">
-            <li><button onclick="showLog('error')">Error Logs</button></li>
-            <li><button onclick="showLog('access')">Access Logs</button></li>
+            <li><button onclick="showLog('jail')">Jail Status</button></li>
+            <li><button onclick="showLog('bans')">Banned IPs</button></li>
         </ul>
         <pre id="log-output"></pre>
     </main>
     <div id="uml-overlay" class="uml-overlay">
         <div class="uml-window">
             <h2>UML Diagram</h2>
-            <img src="uml-diagram.svg" alt="UML diagram" class="uml-img">
+            <img src="fail2ban-uml.svg" alt="Fail2Ban UML" class="uml-img">
             <button onclick="toggleUml()">Close</button>
         </div>
     </div>
     <script>
         function showLog(type) {
-            document.getElementById('log-output').textContent = 'Loading ' + type + ' logs...';
+            document.getElementById('log-output').textContent =
+                'Loading ' + type + ' logs...';
             // Future fetch() call can be placed here
         }
         function toggleUml() {
             const overlay = document.getElementById('uml-overlay');
-            overlay.style.display = overlay.style.display === 'block' ? 'none' : 'block';
+            overlay.style.display =
+                overlay.style.display === 'block' ? 'none' : 'block';
         }
     </script>
 </body>
 </html>
-

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
         <nav class="main-nav">
             <a href="index.html">Home</a>
             <a href="api.html">API Logs</a>
+            <a href="fail2ban.html">Fail2Ban</a>
             <a href="docs.html">Docs</a>
             <a href="#" onclick="toggleUml()">UML</a>
         </nav>


### PR DESCRIPTION
## Summary
- add Fail2Ban logs page and UML diagram
- link Fail2Ban page in the navigation menu
- document new page in README and docs

## Testing
- `python -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_685c84b7ec848332b9f255d21d12aa78