### PR TITLE
Fix header navigation visibility

### DIFF
--- a/header.html
+++ b/header.html
@@ -2,7 +2,7 @@
   <div class="mdl-layout__header-row">
     <span class="mdl-layout-title">Проект</span>
     <div class="mdl-layout-spacer"></div>
-    <nav class="mdl-navigation mdl-layout--large-screen-only">
+    <nav class="mdl-navigation">
       <a class="mdl-navigation__link" href="index.html">Home</a>
       <a class="mdl-navigation__link" href="api.html">API Logs</a>
       <a class="mdl-navigation__link" href="fail2ban.html">Fail2Ban</a>

--- a/styles.css
+++ b/styles.css
@@ -76,6 +76,8 @@ nav.main-nav a {
   font-weight: bold;
 }
 
+
+
 .banner {
   width: 50%;
   max-width: 400px;
@@ -195,4 +197,23 @@ nav.main-nav a {
   color: #000;
   text-decoration: none;
   font-weight: bold;
+}
+
+/* Ensure header navigation does not disappear on narrow screens */
+.mdl-layout__header-row {
+  height: auto;
+}
+
+.mdl-layout__header-row .mdl-navigation {
+  flex-wrap: wrap;
+}
+
+/* Keep UML overlay above other elements */
+.uml-overlay {
+  z-index: 2000;
+}
+
+.uml-window {
+  position: relative;
+  z-index: 2001;
 }


### PR DESCRIPTION
## Summary
- made header navigation always visible by removing the MDL large-screen-only class

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f092daed88332a1d10f6536c81731