### PR TITLE
Расширена поддержка произвольных путей статических файлов

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ HTTP requests could be performed.
 
 Each page includes a menu entry to show a transparent UML overlay with a simple architecture diagram (`uml-diagram.svg`). The Fail2Ban page uses <code>fail2ban-uml.svg</code>.
 Окно диаграммы располагается поверх остальных элементов страницы и имеет полупрозрачный фон.
+Для загрузки меню и подвала теперь используется скрипт `load_layout.js`. Укажите атрибут `data-base` с относительным путём к ресурсам, чтобы страница работала в любой папке, например `/usr/share/django-projects/welcome/static`:
+```html
+<div id="footer-placeholder"></div>
+<script src="load_layout.js" data-base="./"></script>
+```
+Для копирования сайта в целевой каталог запустите `python3 deploy_static.py /usr/share/django-projects/welcome/static`.
+
 
 ## Backend script
 `backend_tools.py` connects to a host via SSH and performs HTTP GET requests.

--- a/api.html
+++ b/api.html
@@ -36,24 +36,7 @@
         }
     </script>
     <div id="footer-placeholder"></div>
-    <script>
-            fetch('header.html').then(r => r.text()).then(t => {
-                const placeholder = document.getElementById('header-placeholder');
-                placeholder.outerHTML = t;
-                if (window.componentHandler) {
-                    const layout = document.querySelector('.mdl-layout');
-                    if (layout) {
-                        layout.classList.remove('is-upgraded');
-                        layout.removeAttribute('data-upgraded');
-                        componentHandler.upgradeElement(layout);
-                    }
-                }
-            });
-        fetch('footer.html').then(r=>r.text()).then(t => {
-            document.getElementById('footer-placeholder').innerHTML = t;
-            if (window.componentHandler) componentHandler.upgradeDom();
-        });
-    </script>
+    <script src="load_layout.js" data-base="./"></script>
 </body>
 </html>
 

--- a/control.html
+++ b/control.html
@@ -59,23 +59,8 @@
         </div>
     </div>
     <div id="footer-placeholder"></div>
+    <script src="load_layout.js" data-base="./"></script>
     <script>
-        fetch('header.html').then(r => r.text()).then(t => {
-            const placeholder = document.getElementById('header-placeholder');
-            placeholder.outerHTML = t;
-            if (window.componentHandler) {
-                const layout = document.querySelector('.mdl-layout');
-                if (layout) {
-                    layout.classList.remove('is-upgraded');
-                    layout.removeAttribute('data-upgraded');
-                    componentHandler.upgradeElement(layout);
-                }
-            }
-        });
-        fetch('footer.html').then(r => r.text()).then(t => {
-            document.getElementById('footer-placeholder').innerHTML = t;
-            if (window.componentHandler) componentHandler.upgradeDom();
-        });
         function toggleUml() {
             const overlay = document.getElementById('uml-overlay');
             overlay.style.display = overlay.style.display === 'flex' ? 'none' : 'flex';

--- a/crossref.html
+++ b/crossref.html
@@ -42,23 +42,8 @@ function	test_list_templates	./tests/test_template_editor.py:11        </pre>
         </div>
     </div>
     <div id="footer-placeholder"></div>
+    <script src="load_layout.js" data-base="./"></script>
     <script>
-            fetch('header.html').then(r => r.text()).then(t => {
-                const placeholder = document.getElementById('header-placeholder');
-                placeholder.outerHTML = t;
-                if (window.componentHandler) {
-                    const layout = document.querySelector('.mdl-layout');
-                    if (layout) {
-                        layout.classList.remove('is-upgraded');
-                        layout.removeAttribute('data-upgraded');
-                        componentHandler.upgradeElement(layout);
-                    }
-                }
-            });
-        fetch('footer.html').then(r=>r.text()).then(t => {
-            document.getElementById('footer-placeholder').innerHTML = t;
-            if (window.componentHandler) componentHandler.upgradeDom();
-        });
         function toggleUml() {
             const overlay = document.getElementById('uml-overlay');
             overlay.style.display = overlay.style.display === 'flex' ? 'none' : 'flex';

--- a/deploy_static.py
+++ b/deploy_static.py
@@ -1,0 +1,36 @@
+import argparse
+import shutil
+from pathlib import Path
+
+EXCLUDE = {'.git', 'docs', 'tests', '__pycache__'}
+EXT_SKIP = {'.py', '.md'}
+
+
+def should_copy(path: Path) -> bool:
+    if path.name in EXCLUDE:
+        return False
+    if path.suffix in EXT_SKIP:
+        return False
+    return True
+
+
+def deploy(src: Path, dst: Path) -> None:
+    dst.mkdir(parents=True, exist_ok=True)
+    for item in src.iterdir():
+        if not should_copy(item):
+            continue
+        target = dst / item.name
+        if item.is_dir():
+            shutil.copytree(item, target, dirs_exist_ok=True)
+        else:
+            shutil.copy2(item, target)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Копирование статических файлов в указанную директорию'
+    )
+    parser.add_argument('target', help='Путь назначения')
+    args = parser.parse_args()
+    deploy(Path(__file__).parent, Path(args.target))
+    print(f'Файлы скопированы в {args.target}')

--- a/docs.html
+++ b/docs.html
@@ -45,23 +45,8 @@
         </div>
     </div>
     <div id="footer-placeholder"></div>
+    <script src="load_layout.js" data-base="./"></script>
     <script>
-            fetch('header.html').then(r => r.text()).then(t => {
-                const placeholder = document.getElementById('header-placeholder');
-                placeholder.outerHTML = t;
-                if (window.componentHandler) {
-                    const layout = document.querySelector('.mdl-layout');
-                    if (layout) {
-                        layout.classList.remove('is-upgraded');
-                        layout.removeAttribute('data-upgraded');
-                        componentHandler.upgradeElement(layout);
-                    }
-                }
-            });
-        fetch('footer.html').then(r=>r.text()).then(t => {
-            document.getElementById('footer-placeholder').innerHTML = t;
-            if (window.componentHandler) componentHandler.upgradeDom();
-        });
         function toggleUml() {
             const overlay = document.getElementById('uml-overlay');
             overlay.style.display = overlay.style.display === 'flex' ? 'none' : 'flex';

--- a/fail2ban.html
+++ b/fail2ban.html
@@ -38,23 +38,6 @@
         }
     </script>
     <div id="footer-placeholder"></div>
-    <script>
-            fetch('header.html').then(r => r.text()).then(t => {
-                const placeholder = document.getElementById('header-placeholder');
-                placeholder.outerHTML = t;
-                if (window.componentHandler) {
-                    const layout = document.querySelector('.mdl-layout');
-                    if (layout) {
-                        layout.classList.remove('is-upgraded');
-                        layout.removeAttribute('data-upgraded');
-                        componentHandler.upgradeElement(layout);
-                    }
-                }
-            });
-        fetch('footer.html').then(r=>r.text()).then(t => {
-            document.getElementById('footer-placeholder').innerHTML = t;
-            if (window.componentHandler) componentHandler.upgradeDom();
-        });
-    </script>
+    <script src="load_layout.js" data-base="./"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -23,24 +23,9 @@
             </div>
         </div>
         <div id="footer-placeholder"></div>
+        <script src="load_layout.js" data-base="./"></script>
         <script src="https://unpkg.com/three@0.160.0/build/three.min.js"></script>
         <script>
-            fetch('header.html').then(r => r.text()).then(t => {
-                const placeholder = document.getElementById('header-placeholder');
-                placeholder.outerHTML = t;
-                if (window.componentHandler) {
-                    const layout = document.querySelector('.mdl-layout');
-                    if (layout) {
-                        layout.classList.remove('is-upgraded');
-                        layout.removeAttribute('data-upgraded');
-                        componentHandler.upgradeElement(layout);
-                    }
-                }
-            });
-            fetch('footer.html').then(r => r.text()).then(t => {
-                document.getElementById('footer-placeholder').outerHTML = t;
-                upgradeMdl();
-            });
             const scene = new THREE.Scene();
             const camera = new THREE.PerspectiveCamera(75, 1, 0.1, 1000);
             const renderer = new THREE.WebGLRenderer({ antialias: true });

--- a/json_intro.html
+++ b/json_intro.html
@@ -26,23 +26,8 @@
 }</pre>
 </main>
 <div id="footer-placeholder"></div>
+    <script src="load_layout.js" data-base="./"></script>
 <script>
-            fetch('header.html').then(r => r.text()).then(t => {
-                const placeholder = document.getElementById('header-placeholder');
-                placeholder.outerHTML = t;
-                if (window.componentHandler) {
-                    const layout = document.querySelector('.mdl-layout');
-                    if (layout) {
-                        layout.classList.remove('is-upgraded');
-                        layout.removeAttribute('data-upgraded');
-                        componentHandler.upgradeElement(layout);
-                    }
-                }
-            });
-  fetch('footer.html').then(r=>r.text()).then(t => {
-    document.getElementById('footer-placeholder').innerHTML = t;
-    if (window.componentHandler) componentHandler.upgradeDom();
-  });
   function toggleUml(){
     const overlay=document.getElementById('uml-overlay');
     if(overlay) overlay.style.display=overlay.style.display==='flex'?'none':'flex';

--- a/load_layout.js
+++ b/load_layout.js
@@ -1,0 +1,24 @@
+(function(){
+  const script = document.currentScript;
+  const base = script.dataset.base || '';
+  function upgradeLayout(){
+    if (window.componentHandler) {
+      const layout = document.querySelector('.mdl-layout');
+      if (layout) {
+        layout.classList.remove('is-upgraded');
+        layout.removeAttribute('data-upgraded');
+        componentHandler.upgradeElement(layout);
+      }
+    }
+  }
+  fetch(base + 'header.html').then(r => r.text()).then(t => {
+    const placeholder = document.getElementById('header-placeholder');
+    placeholder.outerHTML = t;
+    upgradeLayout();
+  });
+  fetch(base + 'footer.html').then(r => r.text()).then(t => {
+    const footer = document.getElementById('footer-placeholder');
+    footer.outerHTML = t;
+    if (window.componentHandler) componentHandler.upgradeDom();
+  });
+})();

--- a/login.html
+++ b/login.html
@@ -44,16 +44,8 @@
         </div>
     </div>
     <div id="footer-placeholder"></div>
+    <script src="load_layout.js" data-base="./"></script>
     <script>
-        fetch('header.html').then(r => r.text()).then(t => {
-            const placeholder = document.getElementById('header-placeholder');
-            placeholder.outerHTML = t;
-            if (window.componentHandler) componentHandler.upgradeDom();
-        });
-        fetch('footer.html').then(r => r.text()).then(t => {
-            document.getElementById('footer-placeholder').innerHTML = t;
-            if (window.componentHandler) componentHandler.upgradeDom();
-        });
         function toggleUml() {
             const overlay = document.getElementById('uml-overlay');
             overlay.style.display = overlay.style.display === 'flex' ? 'none' : 'flex';

--- a/modules.html
+++ b/modules.html
@@ -38,23 +38,8 @@
         </div>
     </div>
     <div id="footer-placeholder"></div>
+    <script src="load_layout.js" data-base="./"></script>
     <script>
-            fetch('header.html').then(r => r.text()).then(t => {
-                const placeholder = document.getElementById('header-placeholder');
-                placeholder.outerHTML = t;
-                if (window.componentHandler) {
-                    const layout = document.querySelector('.mdl-layout');
-                    if (layout) {
-                        layout.classList.remove('is-upgraded');
-                        layout.removeAttribute('data-upgraded');
-                        componentHandler.upgradeElement(layout);
-                    }
-                }
-            });
-        fetch('footer.html').then(r=>r.text()).then(t => {
-            document.getElementById('footer-placeholder').innerHTML = t;
-            if (window.componentHandler) componentHandler.upgradeDom();
-        });
         function toggleUml() {
             const overlay = document.getElementById('uml-overlay');
             overlay.style.display = overlay.style.display === 'flex' ? 'none' : 'flex';

--- a/plan.html
+++ b/plan.html
@@ -45,23 +45,8 @@
         </div>
     </div>
     <div id="footer-placeholder"></div>
+    <script src="load_layout.js" data-base="./"></script>
     <script>
-            fetch('header.html').then(r => r.text()).then(t => {
-                const placeholder = document.getElementById('header-placeholder');
-                placeholder.outerHTML = t;
-                if (window.componentHandler) {
-                    const layout = document.querySelector('.mdl-layout');
-                    if (layout) {
-                        layout.classList.remove('is-upgraded');
-                        layout.removeAttribute('data-upgraded');
-                        componentHandler.upgradeElement(layout);
-                    }
-                }
-            });
-        fetch('footer.html').then(r=>r.text()).then(t => {
-            document.getElementById('footer-placeholder').innerHTML = t;
-            if (window.componentHandler) componentHandler.upgradeDom();
-        });
         function toggleUml() {
             const overlay = document.getElementById('uml-overlay');
             overlay.style.display = overlay.style.display === 'flex' ? 'none' : 'flex';


### PR DESCRIPTION
## Summary
- добавлен `load_layout.js` для динамической подгрузки `header.html` и `footer.html`
- обновлены все HTML-страницы, теперь используется новый скрипт
- добавлен `deploy_static.py` для копирования сайта в любую директорию
- README дополнен описанием скриптов и примерами

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860aedf5b64833289bbbd3b69363f98