### PR TITLE
Fix djangosetup for Python 3.6

### DIFF
--- a/djangosetup.py
+++ b/djangosetup.py
@@ -6,7 +6,6 @@
 OpenAI API с сервером LM Studio.
 """
 
-from __future__ import annotations
 
 import os
 import re


### PR DESCRIPTION
## Summary
- make `djangosetup.py` compatible with Python 3.6 by dropping the `__future__` import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865bc7f78308332a9fe63d7375dd09e