### PR TITLE
Fix djangosetup for Python 3.6 subprocess

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,19 @@ python3 restructure_tools.py --python
 python3 restructure_tools.py --html
 ```
 
+## Django Setup
+
+Скрипт `djangosetup.py` автоматизирует разворачивание проекта под Apache.
+Он совместим с Python 3.6, поэтому может выполняться даже на устаревших
+серверах без обновления интерпретатора.
+Перед запуском установите зависимости:
+
+```bash
+pip install django gunicorn matplotlib pillow
+```
+
+После этого выполните скрипт и следуйте инструкциям в терминале.
+
 
 
 ## Генерация AGENTS.md

--- a/djangosetup.py
+++ b/djangosetup.py
@@ -6,7 +6,6 @@
 OpenAI API с сервером LM Studio.
 """
 
-from __future__ import annotations
 
 import os
 import re
@@ -52,7 +51,14 @@ def analyze_log(text: str) -> str:
 def run(cmd: str, cwd: Optional[Path] = None) -> None:
     """Выполнить команду, вывести вывод и при ошибке предложить анализ."""
     print(f">> {cmd}")
-    proc = subprocess.run(cmd, shell=True, text=True, capture_output=True, cwd=cwd)
+    proc = subprocess.run(
+        cmd,
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        cwd=cwd,
+    )
     if proc.returncode != 0:
         print(proc.stderr)
         print(analyze_log(proc.stderr))
@@ -253,8 +259,9 @@ def main() -> None:
     if log_file.exists():
         text = subprocess.run(
             ["sudo", "tail", "-n", "20", str(log_file)],
-            text=True,
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
         ).stdout
         print("Последние сообщения Apache:")
         print(text)


### PR DESCRIPTION
## Summary
- handle log output capturing without `text=True`/`capture_output`
- document `djangosetup.py` usage in README
- clarify Python 3.6 dependencies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865bc7f78308332a9fe63d7375dd09e